### PR TITLE
Fix compile on stable Rust

### DIFF
--- a/barter-instrument/src/index/builder.rs
+++ b/barter-instrument/src/index/builder.rs
@@ -46,11 +46,11 @@ impl IndexedInstrumentsBuilder {
 
         // Add Instrument OrderQuantityUnits if it's defined in asset units
         // --> likely a duplicate asset, but if so will be filtered during Self::build()
-        if let Some(spec) = instrument.spec.as_ref()
-            && let OrderQuantityUnits::Asset(asset) = &spec.quantity.unit
-        {
-            self.assets
-                .push(ExchangeAsset::new(instrument.exchange, asset.clone()));
+        if let Some(spec) = instrument.spec.as_ref() {
+            if let OrderQuantityUnits::Asset(asset) = &spec.quantity.unit {
+                self.assets
+                    .push(ExchangeAsset::new(instrument.exchange, asset.clone()));
+            }
         }
 
         // Add Instrument

--- a/barter/src/engine/state/instrument/data.rs
+++ b/barter/src/engine/state/instrument/data.rs
@@ -87,10 +87,12 @@ impl<InstrumentKey> Processor<&MarketEvent<InstrumentKey, DataKind>>
                     .last_traded_price
                     .as_ref()
                     .is_none_or(|price| price.time < event.time_exchange)
-                    && let Some(price) = Decimal::from_f64(trade.price)
                 {
-                    self.last_traded_price
-                        .replace(Timed::new(price, event.time_exchange));
+                    if let Some(price) = Decimal::from_f64(trade.price) {
+                        self
+                            .last_traded_price
+                            .replace(Timed::new(price, event.time_exchange));
+                    }
                 }
             }
             DataKind::OrderBookL1(l1) => {

--- a/barter/src/logging.rs
+++ b/barter/src/logging.rs
@@ -44,10 +44,12 @@ where
         _: &tracing::Event<'_>,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        if let Some(span) = ctx.lookup_current()
-            && span.name() == AUDIT_REPLICA_STATE_UPDATE_SPAN_NAME
-        {
-            false
+        if let Some(span) = ctx.lookup_current() {
+            if span.name() == AUDIT_REPLICA_STATE_UPDATE_SPAN_NAME {
+                false
+            } else {
+                true
+            }
         } else {
             true
         }


### PR DESCRIPTION
## Summary
- avoid unstable let chains that prevented building on stable Rust

## Testing
- `cargo check -p barter-instrument`
- `cargo check -p barter`


------
https://chatgpt.com/codex/tasks/task_e_68405cbf986c8323a1e8becc414ae61a