### PR TITLE
Add protobuf parser support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,4 @@ rust_decimal_macros = { version = "1.29.1" }
 bytes = { version = "1.5.0" }
 spin_sleep = { version = "1.3.0 "}
 criterion = { version = "0.5.1" }
+prost = { version = "0.12.4" }

--- a/barter-data/src/exchange/bitfinex/validator.rs
+++ b/barter-data/src/exchange/bitfinex/validator.rs
@@ -82,7 +82,7 @@ impl SubscriptionValidator for BitfinexWebSocketSubValidator {
                         None => break Err(SocketError::Subscribe("WebSocket stream terminated unexpectedly".to_string()))
                     };
 
-                    match Self::Parser::parse::<BitfinexPlatformEvent>(response) {
+                    match <WebSocketParser as StreamParser<BitfinexPlatformEvent>>::parse(response) {
                         Some(Ok(response)) => match response.validate() {
                             // Bitfinex server is online
                             Ok(BitfinexPlatformEvent::PlatformStatus(status)) => {

--- a/barter-data/src/subscriber/validator.rs
+++ b/barter-data/src/subscriber/validator.rs
@@ -19,7 +19,7 @@ use tracing::debug;
 /// [`Subscription`](crate::subscription::Subscription)s were accepted by the execution.
 #[async_trait]
 pub trait SubscriptionValidator {
-    type Parser: StreamParser;
+    type Parser;
 
     async fn validate<Exchange, InstrumentKey, Kind>(
         instrument_map: Map<InstrumentKey>,
@@ -79,7 +79,7 @@ impl SubscriptionValidator for WebSocketSubValidator {
                         None => break Err(SocketError::Subscribe("WebSocket stream terminated unexpectedly".to_string()))
                     };
 
-                    match Self::Parser::parse::<Exchange::SubResponse>(response) {
+                    match <WebSocketParser as StreamParser<Exchange::SubResponse>>::parse(response) {
                         Some(Ok(response)) => match response.validate() {
                             // Subscription success
                             Ok(response) => {

--- a/barter-integration/Cargo.toml
+++ b/barter-integration/Cargo.toml
@@ -62,3 +62,4 @@ chrono = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true, features = ["display", "constructor"] }
+prost = { workspace = true }

--- a/barter-integration/README.md
+++ b/barter-integration/README.md
@@ -61,6 +61,7 @@ At a high level, an `ExchangeStream` is made up of a few major components:
 * StreamParser that is capable of parsing input protocol messages (eg/ WebSocket, FIX, etc.) as exchange
   specific messages.
 * Transformer that transforms from exchange specific message into an iterator of the desired outputs type.
+* Use `ProtobufParser` instead of `WebSocketParser` to decode protobuf WebSocket messages.
 
 ## Examples
 
@@ -335,6 +336,23 @@ where
     data.parse::<T>().map_err(de::Error::custom)
 }
 ```
+
+#### Parsing binary protobuf messages
+
+`ProtobufParser` can decode `WsMessage::Binary` payloads using [`prost`]. It can
+be used with `ExchangeStream` in place of `WebSocketParser` when servers send
+protobuf encoded messages.
+
+```rust
+use barter_integration::protocol::ProtobufParser;
+use barter_integration::protocol::websocket::WebSocket;
+use barter_integration::ExchangeStream;
+
+type ProtoStream<Exchange> = ExchangeStream<ProtobufParser, WebSocket, Exchange, ()>;
+```
+
+[`prost`]: https://crates.io/crates/prost
+
 **For a larger, "real world" example, see the [`Barter-Data`] repository.**
 
 ## Getting Help

--- a/barter-integration/src/error.rs
+++ b/barter-integration/src/error.rs
@@ -1,4 +1,5 @@
 use crate::subscription::SubscriptionId;
+use prost::DecodeError;
 use reqwest::Error;
 use thiserror::Error;
 
@@ -17,6 +18,12 @@ pub enum SocketError {
     #[error("Deserialising JSON error: {error} for binary payload: {payload:?}")]
     DeserialiseBinary {
         error: serde_json::Error,
+        payload: Vec<u8>,
+    },
+
+    #[error("Deserialising protobuf error: {error} for binary payload: {payload:?}")]
+    DeserialiseProtobuf {
+        error: DecodeError,
         payload: Vec<u8>,
     },
 

--- a/barter-integration/src/lib.rs
+++ b/barter-integration/src/lib.rs
@@ -26,6 +26,10 @@
 //!
 //! Both core abstractions provide the robust glue you need to conveniently translate between server & client data models.
 
+// Silence unused dev-dependencies warnings.
+#[cfg(test)]
+use sha2 as _;
+
 use crate::error::SocketError;
 use serde::{Deserialize, Serialize};
 
@@ -73,7 +77,7 @@ pub trait Validator {
 /// `Result<Self::Output, Self::Error>`s.
 pub trait Transformer {
     type Error;
-    type Input: for<'de> Deserialize<'de>;
+    type Input;
     type Output;
     type OutputIter: IntoIterator<Item = Result<Self::Output, Self::Error>>;
     fn transform(&mut self, input: Self::Input) -> Self::OutputIter;

--- a/barter-integration/src/protocol/mod.rs
+++ b/barter-integration/src/protocol/mod.rs
@@ -1,10 +1,10 @@
 use crate::SocketError;
 use futures::Stream;
-use serde::de::DeserializeOwned;
 
 /// Contains useful `WebSocket` type aliases and a default `WebSocket` implementation of a
 /// [`StreamParser`].
 pub mod websocket;
+pub use websocket::ProtobufParser;
 
 /// Contains HTTP client capable of executing signed & unsigned requests, as well as an associated
 /// execution oriented HTTP request.
@@ -12,14 +12,10 @@ pub mod http;
 
 /// `StreamParser`s are capable of parsing the input messages from a given stream protocol
 /// (eg/ WebSocket, Financial Information eXchange (FIX), etc.) and deserialising into an `Output`.
-pub trait StreamParser {
+pub trait StreamParser<Output> {
     type Stream: Stream;
     type Message;
     type Error;
 
-    fn parse<Output>(
-        input: Result<Self::Message, Self::Error>,
-    ) -> Option<Result<Output, SocketError>>
-    where
-        Output: DeserializeOwned;
+    fn parse(input: Result<Self::Message, Self::Error>) -> Option<Result<Output, SocketError>>;
 }

--- a/barter-integration/src/protocol/websocket.rs
+++ b/barter-integration/src/protocol/websocket.rs
@@ -1,5 +1,6 @@
 use crate::{error::SocketError, protocol::StreamParser};
 use bytes::Bytes;
+use prost::Message;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::fmt::Debug;
 use tokio::net::TcpStream;
@@ -33,17 +34,15 @@ pub type WsError = tokio_tungstenite::tungstenite::Error;
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct WebSocketParser;
 
-impl StreamParser for WebSocketParser {
+impl<Output> StreamParser<Output> for WebSocketParser
+where
+    Output: DeserializeOwned,
+{
     type Stream = WebSocket;
     type Message = WsMessage;
     type Error = WsError;
 
-    fn parse<Output>(
-        input: Result<Self::Message, Self::Error>,
-    ) -> Option<Result<Output, SocketError>>
-    where
-        Output: DeserializeOwned,
-    {
+    fn parse(input: Result<Self::Message, Self::Error>) -> Option<Result<Output, SocketError>> {
         match input {
             Ok(ws_message) => match ws_message {
                 WsMessage::Text(text) => process_text(text),
@@ -52,6 +51,41 @@ impl StreamParser for WebSocketParser {
                 WsMessage::Pong(pong) => process_pong(pong),
                 WsMessage::Close(close_frame) => process_close_frame(close_frame),
                 WsMessage::Frame(frame) => process_frame(frame),
+            },
+            Err(ws_err) => Some(Err(SocketError::WebSocket(Box::new(ws_err)))),
+        }
+    }
+}
+
+/// [`StreamParser`] implementation for a [`WebSocket`] that decodes protobuf
+/// binary payloads.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct ProtobufParser;
+
+impl<Output> StreamParser<Output> for ProtobufParser
+where
+    Output: Message + Default,
+{
+    type Stream = WebSocket;
+    type Message = WsMessage;
+    type Error = WsError;
+
+    fn parse(input: Result<Self::Message, Self::Error>) -> Option<Result<Output, SocketError>> {
+        match input {
+            Ok(ws_message) => match ws_message {
+                WsMessage::Binary(binary) => Some(
+                    Output::decode(binary.clone()).map_err(|error| {
+                        SocketError::DeserialiseProtobuf {
+                            error,
+                            payload: binary.to_vec(),
+                        }
+                    }),
+                ),
+                WsMessage::Ping(ping) => process_ping::<Output>(ping),
+                WsMessage::Pong(pong) => process_pong::<Output>(pong),
+                WsMessage::Close(close_frame) => process_close_frame::<Output>(close_frame),
+                WsMessage::Frame(frame) => process_frame::<Output>(frame),
+                WsMessage::Text(_) => None,
             },
             Err(ws_err) => Some(Err(SocketError::WebSocket(Box::new(ws_err)))),
         }

--- a/barter-integration/src/stream/mod.rs
+++ b/barter-integration/src/stream/mod.rs
@@ -17,7 +17,7 @@ pub mod merge;
 #[pin_project]
 pub struct ExchangeStream<Protocol, InnerStream, StreamTransformer>
 where
-    Protocol: StreamParser,
+    Protocol: StreamParser<StreamTransformer::Input>,
     InnerStream: Stream,
     StreamTransformer: Transformer,
 {
@@ -31,7 +31,7 @@ where
 impl<Protocol, InnerStream, StreamTransformer> Stream
     for ExchangeStream<Protocol, InnerStream, StreamTransformer>
 where
-    Protocol: StreamParser,
+    Protocol: StreamParser<StreamTransformer::Input>,
     InnerStream: Stream<Item = Result<Protocol::Message, Protocol::Error>> + Unpin,
     StreamTransformer: Transformer,
     StreamTransformer::Error: From<SocketError>,
@@ -53,7 +53,7 @@ where
             };
 
             // Parse input protocol message into `ExchangeMessage`
-            let exchange_message = match Protocol::parse::<StreamTransformer::Input>(input) {
+            let exchange_message = match Protocol::parse(input) {
                 // `StreamParser` successfully deserialised `ExchangeMessage`
                 Some(Ok(exchange_message)) => exchange_message,
 
@@ -81,7 +81,7 @@ where
 impl<Protocol, InnerStream, StreamTransformer>
     ExchangeStream<Protocol, InnerStream, StreamTransformer>
 where
-    Protocol: StreamParser,
+    Protocol: StreamParser<StreamTransformer::Input>,
     InnerStream: Stream,
     StreamTransformer: Transformer,
 {

--- a/barter/src/lib.rs
+++ b/barter/src/lib.rs
@@ -18,6 +18,8 @@
 //! * **Robust**: Strongly typed. Thread safe. Extensive test coverage.
 //! * **Customisable**: Plug and play Strategy and RiskManager components that facilitates most trading strategies (MarketMaking, StatArb, HFT, etc.).
 //! * **Scalable**: Multithreaded architecture with modular design. Leverages Tokio for I/O. Memory efficient data structures.
+
+// Silence unused dev-dependencies warnings.
 //!
 //! ## Overview
 //! Barter core is a Rust framework for building professional grade live-trading, paper-trading and back-testing systems. The
@@ -36,6 +38,11 @@
 //!
 //! ## Getting Started Via Engine Examples
 //! [See Engine Examples](https://github.com/barter-rs/barter-rs/tree/feat/docs_tests_readmes_examples/barter/examples)
+
+#[cfg(test)]
+use criterion as _;
+#[cfg(test)]
+use serde_json as _;
 
 use crate::{
     engine::{command::Command, state::trading::TradingState},


### PR DESCRIPTION
## Summary
- add `prost` workspace dependency
- expose optional `ProtobufParser` for WebSocket streams
- add socket error for protobuf deserialisation
- document using `ProtobufParser`
- silence warnings about unused dev dependencies

## Testing
- `cargo check --workspace --quiet`
- `cargo test --workspace --all-targets --quiet` *(partial; benchmarks interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684065c5ac54832382451ff17a865b99