### PR TITLE
Add example for MEXC connector

### DIFF
--- a/barter-data/examples/public_trades_streams_mexc.rs
+++ b/barter-data/examples/public_trades_streams_mexc.rs
@@ -1,0 +1,45 @@
+use barter_data::{
+    exchange::mexc::Mexc,
+    streams::{Streams, reconnect::stream::ReconnectingStream},
+    subscription::trade::PublicTrades,
+};
+use barter_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
+use futures_util::StreamExt;
+use tracing::{info, warn};
+
+#[rustfmt::skip]
+#[tokio::main]
+async fn main() {
+    init_logging();
+
+    let streams = Streams::<PublicTrades>::builder()
+        .subscribe([
+            (Mexc, "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
+        ])
+        .subscribe([
+            (Mexc, "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
+        ])
+        .init()
+        .await
+        .unwrap();
+
+    let mut joined_stream = streams
+        .select_all()
+        .with_error_handler(|error| warn!(?error, "MarketStream generated error"));
+
+    while let Some(event) = joined_stream.next().await {
+        info!("{event:?}");
+    }
+}
+
+fn init_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .with_ansi(cfg!(debug_assertions))
+        .json()
+        .init();
+}

--- a/barter-data/src/exchange/mexc/market.rs
+++ b/barter-data/src/exchange/mexc/market.rs
@@ -7,10 +7,12 @@ use barter_instrument::{
 use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, StrExt, format_smolstr};
 
+/// Generated Protobuf types used by this connector.
 pub mod proto {
     include!("protobuf_gen/_.rs");
 }
 
+/// Wrapper around a market symbol, e.g. `BTCUSDT`.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 pub struct MexcMarket(pub SmolStr);
 
@@ -45,3 +47,4 @@ impl AsRef<str> for MexcMarket {
 fn mexc_market(base: &AssetNameInternal, quote: &AssetNameInternal) -> MexcMarket {
     MexcMarket(format_smolstr!("{base}{quote}").to_uppercase_smolstr())
 }
+

--- a/barter-data/src/exchange/mexc/subscription.rs
+++ b/barter-data/src/exchange/mexc/subscription.rs
@@ -2,9 +2,6 @@ use barter_integration::{error::SocketError, Validator};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
-// Note: MexcChannel would be imported from super::channels if this file were in the same module,
-// but subscription request generation is typically handled by the ExchangeChannel trait implementation.
-
 /// Defines the aggregation interval for the MEXC aggregated deals stream.
 ///
 /// Used when constructing the subscription topic string, e.g., "spot@public.aggre.deals.v3.api.pb@100ms@BTCUSDT".

--- a/barter-data/src/exchange/mexc/trade.rs
+++ b/barter-data/src/exchange/mexc/trade.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 
 use crate::{
     event::{MarketEvent, MarketIter},
-    error::DataError, // Import DataError
+    error::DataError,
     subscription::trade::PublicTrade,
 };
 
@@ -21,7 +21,7 @@ fn mexc_trade_type_to_side(trade_type: i32) -> Result<Side, DataError> {
     match trade_type {
         1 => Ok(Side::Buy),
         2 => Ok(Side::Sell),
-        _ => Err(DataError::Socket(format!( // Expects String for DataError::Socket
+        _ => Err(DataError::Socket(format!(
             "Unsupported MexcTrade::Side: unknown trade_type: {}",
             trade_type
         ))),
@@ -30,7 +30,7 @@ fn mexc_trade_type_to_side(trade_type: i32) -> Result<Side, DataError> {
 
 /// Converts a millisecond Unix epoch timestamp (i64) to `DateTime<Utc>`.
 fn ms_epoch_to_datetime_utc(ms: i64) -> Result<DateTime<Utc>, DataError> {
-    if ms < 0 { // Added check for negative timestamps
+    if ms < 0 {
         return Err(DataError::Socket(format!(
             "Unsupported MexcTrade::Timestamp: invalid unix_epoch_ms (negative): {}",
             ms
@@ -198,10 +198,10 @@ mod tests {
         assert_eq!(ms_epoch_to_datetime_utc(timestamp_ms_valid), Ok(expected_datetime));
         
         let timestamp_ms_invalid = -1i64;
-        match ms_epoch_to_datetime_utc(timestamp_ms_invalid) { // Test with -1
-             Err(DataError::Socket(s)) => { 
+        match ms_epoch_to_datetime_utc(timestamp_ms_invalid) {
+            Err(DataError::Socket(s)) => {
                 assert!(s.contains("Unsupported MexcTrade::Timestamp"));
-                assert!(s.contains("invalid unix_epoch_ms (negative): -1")); // Updated error message check
+                assert!(s.contains("invalid unix_epoch_ms (negative): -1"));
             }
             other => panic!("Expected DataError::Socket(String) for negative timestamp, got {:?}", other),
         }


### PR DESCRIPTION
## Summary
- silence warning in MEXC connector
- add an example showing how to stream public trades from MEXC
- polish comments in the mexc module files

## Testing
- `cargo check -p barter-data --examples`
- `cargo test --lib`
- `cargo fmt --all` *(failed: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_684080cac7808323823fa1024a0a6581