### PR TITLE
[barter-data] add Mexc trade deals stream

### DIFF
--- a/barter-data/examples/public_trades_streams_mexc.rs
+++ b/barter-data/examples/public_trades_streams_mexc.rs
@@ -1,7 +1,7 @@
 use barter_data::{
     exchange::mexc::Mexc,
     streams::{Streams, reconnect::stream::ReconnectingStream},
-    subscription::trade::PublicTrades,
+    subscription::{book::OrderBooksL1, trade::PublicTrades},
 };
 use barter_instrument::instrument::market_data::kind::MarketDataInstrumentKind;
 use futures_util::StreamExt;
@@ -12,10 +12,19 @@ use tracing::{info, warn};
 async fn main() {
     init_logging();
 
-    let streams = Streams::<PublicTrades>::builder()
-        .subscribe([
-            (Mexc, "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
-        ])
+    let streams = Streams::builder_multi()
+        .add(
+            Streams::<PublicTrades>::builder().subscribe([
+                (Mexc, "eth", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
+                (Mexc, "btc", "usdt", MarketDataInstrumentKind::Spot, PublicTrades),
+            ]),
+        )
+        .add(
+            Streams::<OrderBooksL1>::builder().subscribe([
+                (Mexc, "eth", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
+                (Mexc, "btc", "usdt", MarketDataInstrumentKind::Spot, OrderBooksL1),
+            ]),
+        )
         .init()
         .await
         .unwrap();

--- a/barter-data/src/exchange/mexc/book/mod.rs
+++ b/barter-data/src/exchange/mexc/book/mod.rs
@@ -1,0 +1,89 @@
+use crate::{
+    books::Level,
+    error::DataError,
+    event::{MarketEvent, MarketIter},
+    subscription::book::OrderBookL1,
+};
+use barter_instrument::exchange::ExchangeId;
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+
+use super::trade::proto;
+
+fn ms_epoch_to_datetime_utc(ms: i64) -> Result<DateTime<Utc>, DataError> {
+    if ms < 0 {
+        return Err(DataError::Socket(format!(
+            "Unsupported MexcBookTicker::Timestamp: invalid unix_epoch_ms (negative): {}",
+            ms
+        )));
+    }
+    DateTime::from_timestamp_millis(ms).ok_or_else(|| {
+        DataError::Socket(format!(
+            "Unsupported MexcBookTicker::Timestamp: invalid unix_epoch_ms: {}",
+            ms
+        ))
+    })
+}
+
+fn parse_level(price: &str, qty: &str) -> Result<Level, DataError> {
+    let price = price.parse::<Decimal>().map_err(|e| {
+        DataError::Socket(format!(
+            "Failed to parse price from MEXC agg book ticker: '{}', error: {}",
+            price, e
+        ))
+    })?;
+    let amount = qty.parse::<Decimal>().map_err(|e| {
+        DataError::Socket(format!(
+            "Failed to parse quantity from MEXC agg book ticker: '{}', error: {}",
+            qty, e
+        ))
+    })?;
+    Ok(Level::new(price, amount))
+}
+
+impl<InstrumentKey> From<(ExchangeId, InstrumentKey, proto::PushDataV3ApiWrapper)>
+    for MarketIter<InstrumentKey, OrderBookL1>
+where
+    InstrumentKey: Clone,
+{
+    fn from(
+        (exchange_id, instrument, wrapper): (
+            ExchangeId,
+            InstrumentKey,
+            proto::PushDataV3ApiWrapper,
+        ),
+    ) -> Self {
+        let time_received = Utc::now();
+        if let Some(proto::push_data_v3_api_wrapper::Body::PublicAggreBookTicker(ticker)) =
+            wrapper.body
+        {
+            let exchange_time = wrapper
+                .send_time
+                .or(wrapper.create_time)
+                .and_then(|ms| ms_epoch_to_datetime_utc(ms).ok())
+                .unwrap_or(time_received);
+
+            let best_bid = match parse_level(&ticker.bid_price, &ticker.bid_quantity) {
+                Ok(lvl) => Some(lvl),
+                Err(err) => return Self(vec![Err(err)]),
+            };
+            let best_ask = match parse_level(&ticker.ask_price, &ticker.ask_quantity) {
+                Ok(lvl) => Some(lvl),
+                Err(err) => return Self(vec![Err(err)]),
+            };
+
+            return Self(vec![Ok(MarketEvent {
+                time_exchange: exchange_time,
+                time_received,
+                exchange: exchange_id,
+                instrument,
+                kind: OrderBookL1 {
+                    last_update_time: exchange_time,
+                    best_bid,
+                    best_ask,
+                },
+            })]);
+        }
+        Self(vec![])
+    }
+}

--- a/barter-data/src/exchange/mexc/channel.rs
+++ b/barter-data/src/exchange/mexc/channel.rs
@@ -1,7 +1,7 @@
 use super::Mexc;
 use crate::{
     Identifier,
-    subscription::{Subscription, trade::PublicTrades},
+    subscription::{Subscription, book::OrderBooksL1, trade::PublicTrades},
 };
 use serde::Serialize;
 
@@ -30,12 +30,21 @@ impl MexcChannel {
     ///
     /// Example base string: "spot@public.aggre.bookTicker.v3.api.pb"
     pub const AGGREGATED_BOOK_TICKER_PB: Self = Self("spot@public.aggre.bookTicker.v3.api.pb");
+    /// Base channel string for [`Mexc`]'s aggregated deals stream.
+    ///
+    /// Used for [`PublicTrades`] subscriptions.
+    pub const AGGREGATED_DEALS_PB: Self = Self("spot@public.aggre.deals.v3.api.pb");
 }
 
 impl<Instrument> Identifier<MexcChannel> for Subscription<Mexc, Instrument, PublicTrades> {
     fn id(&self) -> MexcChannel {
-        // Default to using aggregated book ticker in Protobuf format.
-        // The choice of interval (100ms/10ms) will be handled in the subscription logic.
+        // Use the aggregated deals stream for public trades.
+        MexcChannel::AGGREGATED_DEALS_PB
+    }
+}
+
+impl<Instrument> Identifier<MexcChannel> for Subscription<Mexc, Instrument, OrderBooksL1> {
+    fn id(&self) -> MexcChannel {
         MexcChannel::AGGREGATED_BOOK_TICKER_PB
     }
 }

--- a/barter-data/src/exchange/mexc/mod.rs
+++ b/barter-data/src/exchange/mexc/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     exchange::{Connector, ExchangeSub, PingInterval, StreamSelector},
     instrument::InstrumentData,
     subscriber::WebSocketSubscriber,
-    subscription::{Map, trade::PublicTrades},
+    subscription::{Map, book::OrderBooksL1, trade::PublicTrades},
     transformer::stateless::StatelessTransformer,
 };
 use barter_instrument::exchange::ExchangeId;
@@ -19,14 +19,13 @@ use barter_integration::{
 use barter_macro::{DeExchange, SerExchange};
 use derive_more::Display;
 use serde::Deserialize;
-use serde_json::json;
 use std::{
     borrow::Cow,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{SystemTime, UNIX_EPOCH},
 };
-use tokio::time;
 use url::Url;
 
+pub mod book;
 pub mod channel;
 pub mod market;
 pub mod subscription;
@@ -171,6 +170,21 @@ where
             Self,
             Instrument::Key,
             PublicTrades,
+            self::trade::proto::PushDataV3ApiWrapper,
+        >,
+    >;
+}
+
+impl<Instrument> StreamSelector<Instrument, OrderBooksL1> for Mexc
+where
+    Instrument: InstrumentData,
+{
+    type SnapFetcher = NoInitialSnapshots;
+    type Stream = ExchangeWsPbStream<
+        StatelessTransformer<
+            Self,
+            Instrument::Key,
+            OrderBooksL1,
             self::trade::proto::PushDataV3ApiWrapper,
         >,
     >;

--- a/barter-data/src/subscription/mod.rs
+++ b/barter-data/src/subscription/mod.rs
@@ -272,6 +272,8 @@ pub fn exchange_supports_instrument_kind_sub_kind(
         (GateioPerpetualsBtc, Perpetual, PublicTrades) => true,
         (GateioOptions, Option { .. }, PublicTrades) => true,
         (Kraken, Spot, PublicTrades | OrderBooksL1) => true,
+        (Mexc, Spot, PublicTrades) => true,
+        (Mexc, Spot, OrderBooksL1) => true,
         (Okx, Spot | Future { .. } | Perpetual | Option { .. }, PublicTrades) => true,
 
         (_, _, _) => false,


### PR DESCRIPTION
## Summary
- support aggregated deals channel for Mexc public trades
- parse `PublicAggreDeals` messages into `PublicTrade` events
- allow public trades on Mexc again and order book L1 in parallel
- expand Mexc example with two pairs and both trade & L1 order book subscriptions

## Testing
- `cargo check`
- `cargo test --workspace --quiet` *(failed to finish)*


------
https://chatgpt.com/codex/tasks/task_e_6845920ec7248323b388802730ebbfd6