### PR TITLE
[barter-data] Add MEXC to README table

### DIFF
--- a/barter-data/README.md
+++ b/barter-data/README.md
@@ -60,6 +60,7 @@ arbitrary number of exchange `MarketStream`s using input `Subscription`s. Simply
 |  **GateioOptionsBtc**   |    `GateioOptions::default()`    |                   Option                    |                   PublicTrades                   |
 |       **Kraken**        |             `Kraken`             |                    Spot                     |          PublicTrades <br> OrderBooksL1          |
 |         **Okx**         |              `Okx`               | Spot <br> Future <br> Perpetual <br> Option |                   PublicTrades                   |
+|         **Mexc**         |              `Mexc`              |   Spot                     |                   PublicTrades <br> OrderBooksL1                   |
 
 
 ## Examples


### PR DESCRIPTION
## Summary
- document MEXC connector in the Supported Exchange Subscriptions table

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6845ab6ea2048323963437f929dfca61