### PR TITLE
[barter-data] fix mexc ws sub serialization test

### DIFF
--- a/barter-data/src/exchange/mexc/subscription.rs
+++ b/barter-data/src/exchange/mexc/subscription.rs
@@ -311,7 +311,7 @@ mod tests {
                         ]),
                         id: 123, // Adding an ID for unsubscription
                     },
-                    expected_json: r#"{"method":"SUBSCRIPTION","params":["spot@public.aggre.bookTicker.v3.api.pb@100ms@BTCUSDT"]}"#,
+                    expected_json: r#"{"method":"SUBSCRIPTION","params":["spot@public.aggre.bookTicker.v3.api.pb@100ms@BTCUSDT"],"id":123}"#,
                 },
                 TestCase {
                     name: "TC1: Multiple subscriptions",
@@ -323,7 +323,7 @@ mod tests {
                         ]),
                         id: 123, // Adding an ID for unsubscription
                     },
-                    expected_json: r#"{"method":"SUBSCRIPTION","params":["spot@public.aggre.bookTicker.v3.api.pb@100ms@BTCUSDT","spot@public.aggre.bookTicker.v3.api.pb@10ms@ETHUSDT"]}"#,
+                    expected_json: r#"{"method":"SUBSCRIPTION","params":["spot@public.aggre.bookTicker.v3.api.pb@100ms@BTCUSDT","spot@public.aggre.bookTicker.v3.api.pb@10ms@ETHUSDT"],"id":123}"#,
                 },
                 TestCase {
                     name: "TC2: Unsubscription",
@@ -334,7 +334,7 @@ mod tests {
                         ]),
                         id: 123, // Adding an ID for unsubscription
                     },
-                    expected_json: r#"{"method":"UNSUBSCRIPTION","params":["spot@public.aggre.bookTicker.v3.api.pb@100ms@LTCUSDT"]}"#,
+                    expected_json: r#"{"method":"UNSUBSCRIPTION","params":["spot@public.aggre.bookTicker.v3.api.pb@100ms@LTCUSDT"],"id":123}"#,
                 },
             ];
 


### PR DESCRIPTION
## Summary
- fix expected JSON in MEXC ws subscription serialization test

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test --workspace` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845ab87f9dc8323b9ac29ac35926407